### PR TITLE
Better resolver support

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,13 +4,14 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/Knoppiix/InstagramEmbedResolver/metrics"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"html/template"
 	"log"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/Knoppiix/InstagramEmbedResolver/metrics"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var errorLog = log.New(os.Stderr, "ERROR: ", log.LstdFlags)

--- a/main.go
+++ b/main.go
@@ -61,8 +61,14 @@ func reqHandler(resolvers []Resolver) http.HandlerFunc {
 		}
 		// Else, we simply redirect the user to the instagram post
 
+		// Extract the img_index query parameter if it exists
+		imgIndex := r.URL.Query().Get("img_index")
+		var query string
+		if imgIndex != "" {
+			query = fmt.Sprintf("?img_index=%s", imgIndex)
+		}
 		// Construct the redirect URL
-		redirectURL := "https://instagram.com" + r.URL.Path
+		redirectURL := "https://instagram.com" + r.URL.Path + query
 
 		// Send HTTP 302 redirect
 		http.Redirect(w, r, redirectURL, http.StatusFound)

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"html/template"
@@ -71,16 +70,6 @@ func reqHandler(resolvers []Resolver) http.HandlerFunc {
 	}
 }
 
-func findDefaultResolver(res []Resolver) (Resolver, error) {
-	for _, res := range res {
-		if ok, err := res.isDefault(); err == nil && ok {
-			return res, nil
-			//fmt.Printf("%s is the default resolver.", res.Url)
-		}
-	}
-	return Resolver{}, errors.New("No default resolver was found. Default resolving error behaviour is falling back to a HTTP return.")
-}
-
 func main() {
 	port := flag.Int("p", 8080, "port to run the server on")
 	flag.Parse()
@@ -88,10 +77,6 @@ func main() {
 	resolvers, err := loadResolvers("resolvers.json")
 	if err != nil {
 		log.Fatalf("Error reading the file: %v", err)
-	}
-	defaultRes, err = findDefaultResolver(resolvers)
-	if err != nil {
-		fmt.Printf("WARNING - No default resolver was specified.")
 	}
 	metrics.Init()
 	go monitorResolvers(resolvers)

--- a/main.go
+++ b/main.go
@@ -15,7 +15,20 @@ import (
 
 var errorLog = log.New(os.Stderr, "ERROR: ", log.LstdFlags)
 
-var routes = []string{"/p/", "/reels/", "/reel/"}
+var routes = []string{
+	"/p/{id}",
+	"/p/{id}/{$}",
+	"/reels/{id}",
+	"/reels/{id}/{$}",
+	"/reel/{id}",
+	"/reel/{id}/{$}",
+	"/{username}/p/{id}",
+	"/{username}/p/{id}/{$}",
+	"/{username}/reel/{id}",
+	"/{username}/reel/{id}/{$}",
+	"/share/{id}",
+	"/share/{id}/{$}",
+}
 var defaultRes Resolver
 
 func startServer(resolvers []Resolver, port int) {
@@ -39,17 +52,6 @@ func startServer(resolvers []Resolver, port int) {
 func reqHandler(resolvers []Resolver) http.HandlerFunc {
 	// handler function for proxifying the requests to the resolvers
 	return func(w http.ResponseWriter, r *http.Request) {
-		routeHit := ""
-		for _, route := range routes {
-			if strings.HasPrefix(r.URL.Path, route) {
-				routeHit = route
-				break
-			}
-		}
-		if routeHit == "" {
-			http.NotFound(w, r)
-			return
-		}
 
 		// If the request is from discord OR telegram, we proxify the request through the resolver
 		ua := r.Header.Get("User-Agent")
@@ -59,10 +61,8 @@ func reqHandler(resolvers []Resolver) http.HandlerFunc {
 		}
 		// Else, we simply redirect the user to the instagram post
 
-		// Extract the post ID
-		id := strings.TrimPrefix(r.URL.Path, routeHit)
 		// Construct the redirect URL
-		redirectURL := "https://www.instagram.com" + routeHit + id
+		redirectURL := "https://instagram.com" + r.URL.Path
 
 		// Send HTTP 302 redirect
 		http.Redirect(w, r, redirectURL, http.StatusFound)

--- a/proxy.go
+++ b/proxy.go
@@ -88,6 +88,9 @@ func sendReqToResolver(req *http.Request, client *http.Client, resolver Resolver
 	}
 
 	q := url.Values{}
+	if imgIndex := req.URL.Query().Get("img_index"); imgIndex != "" {
+		q.Set("img_index", imgIndex)
+	}
 	for k, v := range renderMode.Query {
 		q.Set(k, v)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"github.com/Knoppiix/InstagramEmbedResolver/metrics"
-	"github.com/PuerkitoBio/goquery"
 	"io"
 	"log"
 	"net/http"
@@ -11,6 +9,9 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/Knoppiix/InstagramEmbedResolver/metrics"
+	"github.com/PuerkitoBio/goquery"
 )
 
 var metaProps = map[string]bool{

--- a/proxy.go
+++ b/proxy.go
@@ -81,13 +81,24 @@ func sendReqToResolver(req *http.Request, client *http.Client, resolver Resolver
 	}
 
 	// if using a specific mode (gallery, media-only) we check if the current resolver is able to handle it
-	if !isResolverEligible(req, resolver) {
+	renderMode := getRenderMode(req, resolver)
+	if renderMode == nil {
 		log.Printf("The current resolver is not compatible with the request mode.")
 		return
 	}
 
+	q := url.Values{}
+	for k, v := range renderMode.Query {
+		q.Set(k, v)
+	}
+
+	query := ""
+	if len(q) > 0 {
+		query = "?" + q.Encode()
+	}
+
 	// "sanitizing" the URL so we don't carry additionnal parameters (like the ?igsh)
-	fullUrl := u.Scheme + "://" + u.Host + req.URL.Path + "?" + req.URL.RawQuery
+	fullUrl := u.Scheme + "://" + renderMode.Subdomain + u.Host + req.URL.Path + query
 	response.startTime = time.Now()
 	resp, err := client.Get(fullUrl)
 	if err != nil {
@@ -152,27 +163,22 @@ func getMetaTags(doc *goquery.Document) []string {
 	return tags
 }
 
-func isResolverEligible(req *http.Request, res Resolver) bool {
+func getRenderMode(req *http.Request, res Resolver) *RenderMode {
 	host := req.Host
 	host = strings.Split(host, ":")[0] // get rid of the port
 	sub := getSubdomain(host)
 
 	switch sub {
-	// gallery mode
-	case "g.":
-		if res.Gallery {
-			// Instafix's way to enable "gallery mode" (i.e remove the post desc. from embed) is to add this parameter to the URL
-			req.URL.RawQuery = "gallery=true"
-			return true
-		}
-	// subdomain I'm personnally using for testing purpose - whitelisting it here
-	case "tst.":
-		req.Host = strings.ReplaceAll(req.Host, "tst.", "")
-		return true
-	case "":
-		return true
+	case "g":
+		return res.Gallery
+	case "d":
+		return res.Direct
+	case "n":
+		return res.Normal
+	case "tst", "":
+		return &RenderMode{}
 	}
-	return false
+	return nil
 }
 
 func getSubdomain(host string) string {
@@ -182,7 +188,7 @@ func getSubdomain(host string) string {
 	if len(parts) < 3 || parts[0] == "www" {
 		return "" // no subdomain
 	}
-	return parts[0] + "."
+	return parts[0]
 }
 
 // Cleaning the HTML body and replacing the relative URLs from the meta video tags to absolute paths

--- a/resolver.go
+++ b/resolver.go
@@ -14,13 +14,20 @@ import (
 	"golang.org/x/net/ipv4"
 )
 
+type RenderMode struct {
+	Query     map[string]string
+	Subdomain string
+}
+
 type Resolver struct {
 	Url         string
 	UptimeStart time.Time
 	Latency     time.Duration
 	IsUp        bool
 	LastChecked time.Time
-	Gallery     bool // does resolver support the gallery mode (InstaFix does for example)
+	Normal      *RenderMode
+	Gallery     *RenderMode
+	Direct      *RenderMode
 }
 
 func (r *Resolver) IsHttpUp() (bool, error) {

--- a/resolver.go
+++ b/resolver.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -21,7 +20,6 @@ type Resolver struct {
 	Latency     time.Duration
 	IsUp        bool
 	LastChecked time.Time
-	IsDefault   bool // defines the default resolver (fallback)
 	Gallery     bool // does resolver support the gallery mode (InstaFix does for example)
 }
 
@@ -148,12 +146,4 @@ func (r Resolver) ResolveEmbed(id string) string {
 
 	return string(bodyBytes)
 
-}
-
-func (r Resolver) isDefault() (bool, error) {
-	if r.IsDefault {
-		return true, nil
-	}
-
-	return false, errors.New("No default resolver was specified. Falling back to http redirection as default behavior.")
 }

--- a/resolvers.json
+++ b/resolvers.json
@@ -1,8 +1,8 @@
 [
-  { "Url": "https://vxinstagram.com" },
-  { "Url": "https://eeinstagram.com", "Gallery": true },
-  { "Url": "https://uuinstagram.com", "Gallery": true },
-  { "Url": "https://fxstagram.com", "Gallery": true },
-  { "Url": "https://kkinstagram.com" },
-  { "Url": "https://instafix.zzinstagram.com", "Gallery": true }
+  { "Url": "https://vxinstagram.com", "Direct": {} },
+  { "Url": "https://eeinstagram.com", "Normal": {}, "Direct": { "Query":  { "direct": "true" } }, "Gallery": { "Query":  { "gallery": "true" } } },
+  { "Url": "https://uuinstagram.com", "Normal": {}, "Direct": { "Query":  { "direct": "true" } }, "Gallery": { "Query":  { "gallery": "true" } } },
+  { "Url": "https://fxstagram.com", "Normal": {}, "Direct": { "Query":  { "direct": "true" } }, "Gallery": { "Query":  { "gallery": "true" } } },
+  { "Url": "https://kkinstagram.com", "Direct": {} },
+  { "Url": "https://instafix.zzinstagram.com", "Normal": {}, "Direct": { "Query":  { "direct": "true" } }, "Gallery": { "Query":  { "gallery": "true" } } }
 ]

--- a/resolvers.json
+++ b/resolvers.json
@@ -1,5 +1,5 @@
 [
-  { "Url": "https://vxinstagram.com", "IsDefault": true },
+  { "Url": "https://vxinstagram.com" },
   { "Url": "http://eeinstagram.com", "Gallery": true },
   { "Url": "https://uuinstagram.com", "Gallery": true }
 ]

--- a/resolvers.json
+++ b/resolvers.json
@@ -1,5 +1,8 @@
 [
   { "Url": "https://vxinstagram.com" },
-  { "Url": "http://eeinstagram.com", "Gallery": true },
-  { "Url": "https://uuinstagram.com", "Gallery": true }
+  { "Url": "https://eeinstagram.com", "Gallery": true },
+  { "Url": "https://uuinstagram.com", "Gallery": true },
+  { "Url": "https://fxstagram.com", "Gallery": true },
+  { "Url": "https://kkinstagram.com" },
+  { "Url": "https://instafix.zzinstagram.com", "Gallery": true }
 ]


### PR DESCRIPTION
## Why

I have a couple of issues with the actual project:
1. There are a couple existing resolvers that aren't used.
2. By default, the embed has a random style, and the only style that can be chosen and enforced is the gallery mode.
3. The carousel position isn't preserved when sharing image posts.
4. A lot of urls aren't supported. 

## Changes

- Add additional resolvers (`fxstagram.com` — which is currently on pause, `kkinstagram.com`, and, obviously, `instafix.zzinstagram.com`).
- Add more mode support: `Normal` (full info + description + media) and `Direct` (only media, without the embed card).
    - This works by using an advanced configuration system where you can precise which modes are supported, and for each mode, how is it enabled: the subdomain to use, if any, and the query parameters to use, if any.
	- The actual default behavior (use whatever the default resolver mode is) is preserved, "Normal" mode isn't the default.
	- Note that, in order to make the new modes work, the subdomains `n` and `d` must be added to the server configuration.
- Preserve the query parameter `img_index`, which is indicating the selected image within the image carousel, both for redirection and resolver request.
- Add support for more paths.
- Remove unused "default resolver" logic.
- Re-organize import statements to separate Go packages from GitHub ones. *Note that I didn't particularly want to do this, but my IDE didn't leave me the choice. I don't have any issue with reversing this one.*

## Additional comments

Thanks for this project and your work! It is a great idea, and it has been life-saving for a lot of people.

I put multiple, different things in a single PR because some of these are pretty linked together, but, if needed, this can be multiple PRs. I already separated it into multiple commits, to separate changes as possible.

If this PR is merged, a couple things have to be done:
- As said earlier, the addition of two new modes implies the update of the main/official instance configuration to support two new subdomains: `n` for normal mode, and `d` for direct mode.
- The Readme has to be updated to reflect these changes. I didn't touch it because it's kind of a personal work, and everyone has its way of explaining things, so I left it up to you.
- The monitoring page and the Grafana page probably needs an update with the addition of the new resolvers.